### PR TITLE
Added match_24h_format option which changes the plugin behaviour to b…

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -172,6 +172,12 @@ $('#to-french').timeAutocomplete({
                     <td></td>
                     <td>The default empty value</td>
                 </tr>
+                <tr>
+                    <td><a name="match_24h_format"></a>match_24h_format</td>
+                    <td>false</td>
+                    <td>true | false</td>
+                    <td>If true, when user enters 12 it becomes 12PM, when user enters 0 it becomes 12AM in order to match 24h format.</td>
+                </tr>
             </tbody>
         </table>
 

--- a/src/formatters/ampm.js
+++ b/src/formatters/ampm.js
@@ -109,8 +109,15 @@
                         });
                     }
 
-                    responseFn(a);
+                    if(self.options.match_24h_format) {
 
+                        if(self_val == 12) {
+                            var amArr = a.splice(0, 4),
+                                a = a.concat(amArr);
+                        }
+                    }
+
+                    responseFn(a);
                 }
             })(self.options.times, self);
 
@@ -126,6 +133,9 @@
             // Clean up 03:00 am
             if(val.charAt(0) == 0){
                 val = val.substr(1);
+                if(!val) {
+                    val = "0";
+                }
             }
 
             return val;
@@ -154,6 +164,15 @@
         hook_readMind: function(val){
 
             var am_pm = '';
+
+            if(this.options.match_24h_format) {
+                if(val == 12 || (val >= 1200 && val <= 1300)) {
+                    am_pm = 'PM';
+                } 
+                if (val == 0) {
+                    am_pm = 'AM';
+                }
+            }
 
             val = val.toLowerCase();
             if(this.options.from_selector && !~val.indexOf('a') && !~val.indexOf('p'))

--- a/src/jquery.timeAutocomplete.js
+++ b/src/jquery.timeAutocomplete.js
@@ -38,7 +38,8 @@
             },
             auto_value: true,
             value: '',
-            formatter: 'ampm'
+            formatter: 'ampm',
+            match_24h_format: false
         },
 
         /**


### PR DESCRIPTION
…e consistent with 24h format when it works with am/pm time format. If match_24h_format is true the plugin behaves next way: when an user enters 12, it becomes 12PM, because this would be consistent with the 24h time format. Also the plugin accepts 0 as 12AM.
